### PR TITLE
Disable native auth & setup publishing of fork

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,37 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  push:
+    branches:
+      - alpha
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/Parse-Dashboard/app.js
+++ b/Parse-Dashboard/app.js
@@ -69,7 +69,7 @@ module.exports = function(config, options) {
     const users = config.users;
     const useEncryptedPasswords = config.useEncryptedPasswords ? true : false;
     const authInstance = new Authentication(users, useEncryptedPasswords, mountPath);
-    authInstance.initialize(app, { cookieSessionSecret: options.cookieSessionSecret, cookieSessionMaxAge: options.cookieSessionMaxAge });
+    //authInstance.initialize(app, { cookieSessionSecret: options.cookieSessionSecret, cookieSessionMaxAge: options.cookieSessionMaxAge });
 
     // CSRF error handler
     app.use(function (err, req, res, next) {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "parse-dashboard",
+  "name": "@tyraorg/parse-dashboard",
   "version": "7.0.0-alpha.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ParsePlatform/parse-dashboard"
+    "url": "git+https://github.com/tyraorg/parse-dashboard.git"
   },
   "description": "The Parse Dashboard",
   "parseDashboardFeatures": [
@@ -25,8 +25,6 @@
     "parse",
     "dashboard"
   ],
-  "homepage": "https://github.com/ParsePlatform/parse-dashboard",
-  "bugs": "https://github.com/ParsePlatform/parse-dashboard/issues",
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "Parse-Dashboard",


### PR DESCRIPTION
This PR hijacks Parse Dashboard's authentication flow to work with an external IDP.

A new GH workflow for publishing of the work is also added.